### PR TITLE
Update Mapping.ts to make use of transaction hash 

### DIFF
--- a/src/mapping.ts
+++ b/src/mapping.ts
@@ -1,35 +1,35 @@
-import { BigInt } from "@graphprotocol/graph-ts"
+import { BigInt } from "@graphprotocol/graph-ts";
 import {
   ExchangeFactory,
   NewExchange,
   OwnershipTransferred,
-  SetFeeAddress
-} from "../generated/ExchangeFactory/ExchangeFactory"
-import { ExampleEntity } from "../generated/schema"
+  SetFeeAddress,
+} from "../generated/ExchangeFactory/ExchangeFactory";
+import { ExampleEntity } from "../generated/schema";
 
 export function handleNewExchange(event: NewExchange): void {
   // Entities can be loaded from the store using a string ID; this ID
   // needs to be unique across all entities of the same type
-  let entity = ExampleEntity.load(event.transaction.from.toHex())
+  let entity = ExampleEntity.load(event.transaction.hash.toHex());
 
   // Entities only exist after they have been saved to the store;
   // `null` checks allow to create entities on demand
   if (!entity) {
-    entity = new ExampleEntity(event.transaction.from.toHex())
+    entity = new ExampleEntity(event.transaction.hash.toHex());
 
     // Entity fields can be set using simple assignments
-    entity.count = BigInt.fromI32(0)
+    entity.count = BigInt.fromI32(0);
   }
 
   // BigInt and BigDecimal math are supported
-  entity.count = entity.count + BigInt.fromI32(1)
+  entity.count = entity.count + BigInt.fromI32(1);
 
   // Entity fields can be set based on event parameters
-  entity.creator = event.params.creator
-  entity.exchangeAddress = event.params.exchangeAddress
+  entity.creator = event.params.creator;
+  entity.exchangeAddress = event.params.exchangeAddress;
 
   // Entities can be written to the store with `.save()`
-  entity.save()
+  entity.save();
 
   // Note: If a handler doesn't require existing field values, it is faster
   // _not_ to load the entity from the store. Instead, create it fresh with


### PR DESCRIPTION
instead of transaction from, to keep every transaction as unique and instantiated with a unique ID.